### PR TITLE
feat: always clear cache on canvas unmount

### DIFF
--- a/app/library/dicom/render/Canvas.vue
+++ b/app/library/dicom/render/Canvas.vue
@@ -44,6 +44,7 @@ import { stackMetadata as stackMetadataDict, stackTools } from "../defaults";
 import {
   addTools,
   clearSeriesData,
+  clearSeriesCache,
   deleteViewport,
   disableCanvas,
   getSeriesStack,
@@ -96,6 +97,9 @@ export default {
       // disable larvitar canvas
       disableCanvas(this.$refs.canvas);
       deleteViewport(this.$refs.canvas);
+
+      // clear cache (!!! NOTE: cornerstone should not cache images if not required)
+      clearSeriesCache(this.seriesId);
 
       if (this.clearOnDestroy) {
         clearSeriesData(this.seriesId, this.clearCacheOnDestroy);

--- a/app/library/dicom/utils.js
+++ b/app/library/dicom/utils.js
@@ -64,6 +64,8 @@ export const buildData = stack => {
 
 export const buildHeader = lt.buildHeader;
 
+export const clearSeriesCache = lt.clearImageCache;
+
 // Remove viewport data from larvitar stores
 export const clearSeriesData = (seriesId, clearCache = false) => {
   lt.removeSeriesFromLarvitarManager(seriesId);


### PR DESCRIPTION
@daron1337 la cosa più corretta sarebbe gestire la cancellazione della cache solo quando esplicitamente io chiedo di cachare le immagini, come era prima. Fatto così dovrebbe risolvere il problema (anche se non so come verificarlo) ma ho lasciato una nota nel codice per ricordarci il motivo di questa modifica.