### PR TITLE
feat: lazy render dicom images

### DIFF
--- a/app/library/dicom/import/steps/Step2.vue
+++ b/app/library/dicom/import/steps/Step2.vue
@@ -91,15 +91,17 @@
       </template>
 
       <template v-slot:[`item.preview`]="{ item }">
-        <dicom-canvas
-          :canvas-id="item.larvitarSeriesInstanceUID"
-          :get-progress-fn="getProgressFn"
-          :get-viewport-fn="getViewportFn"
-          :series-id="item.larvitarSeriesInstanceUID"
-          :stack="item"
-          :style="{ width: '10em', height: '10em' }"
-          :tools="tools"
-        />
+        <v-lazy>
+          <dicom-canvas
+            :canvas-id="item.larvitarSeriesInstanceUID"
+            :get-progress-fn="getProgressFn"
+            :get-viewport-fn="getViewportFn"
+            :series-id="item.larvitarSeriesInstanceUID"
+            :stack="item"
+            :style="{ width: '10em', height: '10em' }"
+            :tools="tools"
+          />
+        </v-lazy>
       </template>
 
       <template

--- a/app/library/dicom/sop/SeriesSummary.vue
+++ b/app/library/dicom/sop/SeriesSummary.vue
@@ -2,16 +2,17 @@
   <div>
     <!-- thumbnail or dicom canvas -->
     <thumbnail-string v-if="showThumbnail" :value="data.thumbnail" />
-    <dicom-canvas
-      v-else-if="showCanvas"
-      :canvas-id="canvasId || data.larvitarSeriesInstanceUID"
-      :clear-cache-on-destroy="clearCacheOnDestroy"
-      :clear-on-destroy="clearOnDestroy"
-      :series-id="data.larvitarSeriesInstanceUID"
-      :show-progress="showProgress"
-      :style="{ height: '10em', width: '100%' }"
-      :tools="tools"
-    />
+    <v-lazy v-else-if="showCanvas">
+      <dicom-canvas
+        :canvas-id="canvasId || data.larvitarSeriesInstanceUID"
+        :clear-cache-on-destroy="clearCacheOnDestroy"
+        :clear-on-destroy="clearOnDestroy"
+        :series-id="data.larvitarSeriesInstanceUID"
+        :show-progress="showProgress"
+        :style="{ height: '10em', width: '100%' }"
+        :tools="tools"
+      />
+    </v-lazy>
 
     <div class="d-flex">
       <div class="flex-grow-1 ma-auto lh-small pa-1">


### PR DESCRIPTION
Dicom previews images are rendered only when the canvas comes into view (when the user scrolls down the lists)