### PR TITLE
fix: missing promise

### DIFF
--- a/app/library/dicom/README.md
+++ b/app/library/dicom/README.md
@@ -491,6 +491,7 @@ The utils module provides utilities methods based on _larvitar_. **The aim of th
 - _getSeriesStack(seriesId)_: reads the series stack from the _larvitar_ manager
 - _mergeSeries(...series)_: merges the instances of a list of series into a single series object if their instance uids matches
 - _parseFiles(files, extractMetadata = [])_: uses _larvitar_ to parse files and get series stacks, extracting the required metadata
+- _parseFile(seriesId, file)_: uses _larvitar_ to parse a single file and get single image stack object
 - _renderSeries(elementId, seriesStack)_: calls the _larvitar_ _larvitar_store.addViewport_ and _renderImage_ functions
 - _resizeViewport_: calls the _larvitar_ _resizeViewport_ function
 - _seriesIdToElementId(seriesId)_: replaces dots with underscores to get a valid html element id

--- a/app/library/dicom/utils.js
+++ b/app/library/dicom/utils.js
@@ -163,14 +163,18 @@ export const parseFiles = (files, extractMetadata = []) => {
 // Use Larvitar to parse a single file and get its dicom image object
 export const parseFile = (seriesId, file) => {
   // Get DICOM image object
-  return new Promise(resolve => {
-    lt.readFile(file, (image, error) => {
-      let manager = lt.updateLarvitarManager(image, seriesId)[seriesId];
-      let imageIds = manager.imageIds;
-      let imageUID = image.metadata.instanceUID;
-      let imageId = manager.instanceUIDs[imageUID];
-      return resolve({ imageIds, imageId, error });
-    });
+  return new Promise((resolve, reject) => {
+    lt.readFile(file)
+      .then(image => {
+        let manager = lt.updateLarvitarManager(image, seriesId)[seriesId];
+        let imageIds = manager.imageIds;
+        let imageUID = image.metadata.instanceUID;
+        let imageId = manager.instanceUIDs[imageUID];
+        return resolve({ imageIds, imageId });
+      })
+      .catch(error => {
+        return reject(error);
+      });
   });
 };
 
@@ -178,7 +182,7 @@ export const parseFile = (seriesId, file) => {
 export const renderSeries = (elementId, seriesStack, params = {}) => {
   lt.larvitar_store.addViewport(elementId);
   // renderImage returns a promise which will resolve when image is displayed
-  return lt.renderImage(seriesStack, elementId);
+  return lt.renderImage(seriesStack, elementId, params);
 };
 
 // Call the Larvitar "resizeViewport" function
@@ -248,7 +252,7 @@ export const updateViewportProperty = (action, element) => {
     }
     case "export-viewport": {
       let canvas = document.getElementById(element).children[1];
-      canvas.toBlob(function (blob) {
+      canvas.toBlob(function(blob) {
         saveAs(blob, "image.png");
       });
       break;
@@ -256,7 +260,7 @@ export const updateViewportProperty = (action, element) => {
 
     case "print-viewport": {
       let canvas = document.getElementById(element).children[1];
-      canvas.toBlob(function (blob) {
+      canvas.toBlob(function(blob) {
         print({
           printable: URL.createObjectURL(blob),
           type: "image",


### PR DESCRIPTION
Aggiunto la promise mancante in "readFile" e fixato un parametro mancante in renderSeries

@zansa readFile è stato inserita poco tempo fa, di fatto da la possibilità di parsare una singola immagine di una serie e renderizzarla immediatamente mentre le restanti vengono scaricate e vienen popolato in background il larvitar manager