### PR TITLE
feat: added info for timeseries

### DIFF
--- a/app/library/dicom/defaults.js
+++ b/app/library/dicom/defaults.js
@@ -29,7 +29,8 @@ export const stackMetadata = {
     "larvitarSeriesInstanceUID",
     "larvitarNumberOfSlices",
     // Larvitar info
-    "isMultiframe"
+    "isMultiframe",
+    "isTimeserie"
   ]
 };
 

--- a/app/library/dicom/render/CanvasData.vue
+++ b/app/library/dicom/render/CanvasData.vue
@@ -23,8 +23,14 @@
       </div>
     </template>
     <div v-if="data.maxSliceId">
-      slice: {{ data.sliceId + 1 }}/{{ data.maxSliceId }}
+      <div v-if="data.isTimeserie">
+        slice: {{ Math.ceil((data.sliceId + 1) / (data.maxTimeId + 1)) }}/{{
+          (data.maxSliceId + 1) / (data.maxTimeId + 1) + 1
+        }}
+      </div>
+      <div v-else>slice: {{ data.sliceId + 1 }}/{{ data.maxSliceId + 1 }}</div>
     </div>
+    <div v-if="data.isTimeserie">time: {{ data.timestamp }}</div>
   </div>
 </template>
 


### PR DESCRIPTION
- Sistemato il bug dello sliceId, in larvitar tutti gli indici sono da 0 a N-1
- Aggiunta informazione sulla "fetta" visualizzata ed il suo timestamp per le timeseries